### PR TITLE
fix: vscode ts서버 터지는 문제 해결

### DIFF
--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "5.6.3-sdk",
+  "version": "5.4.3-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "scripts": {
     "server": "yarn workspace server",
     "client": "yarn workspace client"
+  },
+  "devDependencies": {
+    "typescript": "5.4.3"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.13",
     "globals": "^15.11.0",
-    "typescript": "~5.6.2",
+    "typescript": "5.4.3",
     "typescript-eslint": "^8.10.0",
     "vite": "^5.4.9"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,7 +2828,7 @@ __metadata:
     globals: "npm:^15.11.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:~5.6.2"
+    typescript: "npm:5.4.3"
     typescript-eslint: "npm:^8.10.0"
     vite: "npm:^5.4.9"
   languageName: unknown
@@ -7456,7 +7456,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.1.3, typescript@npm:~5.6.2":
+"typescript@npm:5.4.3":
+  version: 5.4.3
+  resolution: "typescript@npm:5.4.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/22443a8760c3668e256c0b34b6b45c359ef6cecc10c42558806177a7d500ab1a7d7aac1f976d712e26989ddf6731d2fbdd3212b7c73290a45127c1c43ba2005a
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.1.3":
   version: 5.6.3
   resolution: "typescript@npm:5.6.3"
   bin:
@@ -7476,7 +7486,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.1.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.6.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.4.3#optional!builtin<compat/typescript>":
+  version: 5.4.3
+  resolution: "typescript@patch:typescript@npm%3A5.4.3#optional!builtin<compat/typescript>::version=5.4.3&hash=5adc0c"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/6e51f8b7e6ec55b897b9e56b67e864fe8f44e30f4a14357aad5dc0f7432db2f01efc0522df0b6c36d361c51f2dc3dcac5c832efd96a404cfabf884e915d38828
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.1.3#optional!builtin<compat/typescript>":
   version: 5.6.3
   resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
@@ -7670,6 +7690,8 @@ __metadata:
 "web03-CorinEE@workspace:.":
   version: 0.0.0-use.local
   resolution: "web03-CorinEE@workspace:."
+  dependencies:
+    typescript: "npm:5.4.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## ✅ 작업 내용
https://github.com/microsoft/vscode/issues/213505

vscode 내의 ts 서버가 터지는 이슈 출현
서칭해보니 typescript 최신 버전과 yarn berry 버전이 충돌나는 문제였음.
typescript 버전을 5.4.3으로 낮추고 문제 해결
