### PR TITLE
[FE] - feature#39 비트코인 차트 구현(일/주/월/년), 차트 반응형 구현

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,6 +13,7 @@
     "@material-tailwind/react": "^2.1.10",
     "@tanstack/react-query": "^5.59.19",
     "axios": "^1.7.7",
+    "lightweight-charts": "^4.2.1",
     "lottie-react": "^2.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/client/src/api/coin.ts
+++ b/packages/client/src/api/coin.ts
@@ -1,5 +1,5 @@
 import { instance } from '@/api/instance';
-import { Candle } from '@/types/chart';
+import { Candle, CandlePeriod } from '@/types/chart';
 import { MarketData } from '@/types/market';
 
 export async function getMarketAll(): Promise<MarketData[]> {
@@ -9,7 +9,7 @@ export async function getMarketAll(): Promise<MarketData[]> {
 
 export async function getCandleByPeriod(
 	market: string,
-	params: 'days' | 'weeks' | 'months' | 'years',
+	params: CandlePeriod,
 ): Promise<Candle[]> {
 	const response = await instance.get(`/candles/${params}`, {
 		params: {

--- a/packages/client/src/api/coin.ts
+++ b/packages/client/src/api/coin.ts
@@ -1,7 +1,22 @@
 import { instance } from '@/api/instance';
+import { Candle } from '@/types/chart';
 import { MarketData } from '@/types/market';
 
-export async function getMarketAll(): Promise<MarketData[]>  {
+export async function getMarketAll(): Promise<MarketData[]> {
 	const response = await instance.get('/market/all?is_details=true');
+	return response.data;
+}
+
+export async function getCandleByPeriod(
+	market: string,
+	params: 'days' | 'weeks' | 'months' | 'years',
+): Promise<Candle[]> {
+	const response = await instance.get(`/candles/${params}`, {
+		params: {
+			market,
+			count: 200,
+			to: '',
+		},
+	});
 	return response.data;
 }

--- a/packages/client/src/hooks/usePeriodChart.ts
+++ b/packages/client/src/hooks/usePeriodChart.ts
@@ -1,0 +1,14 @@
+import { getCandleByPeriod } from '@/api/coin';
+import { CandlePeriod } from '@/types/chart';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export function usePeriodChart(market: string, period: CandlePeriod) {
+	const { data } = useSuspenseQuery({
+		queryKey: [market, period],
+		queryFn: () => getCandleByPeriod(market, period),
+		staleTime: 1000 * 60, // 1분
+		gcTime: 1000 * 60 * 5, // 5분
+	});
+
+	return { data };
+}

--- a/packages/client/src/pages/trade/Trade.tsx
+++ b/packages/client/src/pages/trade/Trade.tsx
@@ -1,10 +1,12 @@
-import Chart from '@/pages/trade/components/Chart';
+import Chart from '@/pages/trade/components/chart/Chart';
 import OrderBook from '@/pages/trade/components/OrderBook';
 import OrderForm from '@/pages/trade/components/order_form/OrderForm';
 import TradeHeader from '@/pages/trade/components/trade_header/TradeHeader';
 import { useParams } from 'react-router-dom';
 import { useSSETicker } from '@/hooks/useSSETicker';
-import { useMemo } from 'react';
+import { Suspense, useMemo } from 'react';
+import ChartSkeleton from '@/pages/trade/components/chart/ChartSkeleton';
+
 function Trade() {
 	const { market } = useParams();
 	const marketCode = useMemo(() => (market ? [{ market }] : []), [market]);
@@ -12,11 +14,14 @@ function Trade() {
 	if (!market) return;
 	if (!sseData) return;
 	const currentPrice = sseData[market]?.trade_price;
+
 	return (
 		<div className="w-full h-full gap-2">
 			<TradeHeader market={market} sseData={sseData} />
 			<div className="flex gap-2 min-h-[700px]">
-				<Chart />
+				<Suspense fallback={<ChartSkeleton />}>
+					<Chart market={market} />
+				</Suspense>
 				<OrderBook />
 				<OrderForm currentPrice={currentPrice} />
 			</div>

--- a/packages/client/src/pages/trade/components/Chart.tsx
+++ b/packages/client/src/pages/trade/components/Chart.tsx
@@ -1,5 +1,0 @@
-function Chart() {
-	return <div className="bg-gray-50 w-2/3 min-w-96 rounded-lg">Chart</div>;
-}
-
-export default Chart;

--- a/packages/client/src/pages/trade/components/OrderBook.tsx
+++ b/packages/client/src/pages/trade/components/OrderBook.tsx
@@ -1,5 +1,5 @@
 function OrderBook() {
-	return <div className="bg-gray-50 w-1/3 min-w-96 rounded-lg">OrderBook</div>;
+	return <div className="bg-gray-50 flex-1 min-w-80 rounded-lg">OrderBook</div>;
 }
 
 export default OrderBook;

--- a/packages/client/src/pages/trade/components/chart/CandleChart.tsx
+++ b/packages/client/src/pages/trade/components/chart/CandleChart.tsx
@@ -1,0 +1,63 @@
+import { useRef } from 'react';
+import { useEffect } from 'react';
+import { Candle } from '@/types/chart';
+import { IChartApi, ISeriesApi } from 'lightweight-charts';
+import {
+	initializeChart,
+	setupCandlestickSeries,
+} from '@/pages/trade/components/chart/chartSetup';
+import { chartConfig } from '@/pages/trade/components/chart/config';
+import { formatCandleData } from '@/utility/formatCandleData';
+
+function CandleChart({ data }: { data: Candle[] }) {
+	const chartRef = useRef<HTMLDivElement>(null);
+	const chartInstanceRef = useRef<IChartApi | null>(null);
+	const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+
+	const handleResize = () => {
+		// resize 로직 추후 파일 분리 예정
+		if (chartRef.current && chartInstanceRef.current) {
+			const { width } =
+				chartRef.current.parentElement?.getBoundingClientRect() || { width: 0 };
+			chartInstanceRef.current.applyOptions({
+				width: width,
+			});
+		}
+	};
+
+	useEffect(() => {
+		if (!chartRef.current) return;
+
+		chartInstanceRef.current = initializeChart(chartRef.current, chartConfig);
+		seriesRef.current = setupCandlestickSeries(
+			chartInstanceRef.current,
+			[],
+			chartConfig,
+		);
+
+		const resizeObserver = new ResizeObserver(() => {
+			handleResize();
+		});
+
+		if (chartRef.current.parentElement) {
+			resizeObserver.observe(chartRef.current.parentElement);
+		}
+
+		return () => {
+			if (chartInstanceRef.current) {
+				resizeObserver.disconnect();
+				chartInstanceRef.current.remove();
+			}
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!seriesRef.current) return;
+		const formattedData = formatCandleData(data);
+		seriesRef.current.setData(formattedData);
+	}, [data]);
+
+	return <div ref={chartRef} />;
+}
+
+export default CandleChart;

--- a/packages/client/src/pages/trade/components/chart/Chart.tsx
+++ b/packages/client/src/pages/trade/components/chart/Chart.tsx
@@ -1,0 +1,25 @@
+import { usePeriodChart } from '@/hooks/usePeriodChart';
+import { useState } from 'react';
+import ChartSelector from '@/pages/trade/components/chart/ChartSelector';
+import { CandlePeriod } from '@/types/chart';
+import CandleChart from '@/pages/trade/components/chart/CandleChart';
+function Chart({ market }: { market: string }) {
+	const [activePeriod, setActivePeriod] = useState<CandlePeriod>('days');
+
+	const { data } = usePeriodChart(market, activePeriod);
+	const handleActivePeriod = (period: CandlePeriod) => {
+		setActivePeriod(period);
+	};
+
+	return (
+		<div className="bg-gray-50 rounded-lg flex-[2] overflow-hidden">
+			<ChartSelector
+				activePeriods={activePeriod}
+				handleActivePeriod={handleActivePeriod}
+			/>
+			<CandleChart data={data} />
+		</div>
+	);
+}
+
+export default Chart;

--- a/packages/client/src/pages/trade/components/chart/ChartSelector.tsx
+++ b/packages/client/src/pages/trade/components/chart/ChartSelector.tsx
@@ -1,0 +1,46 @@
+import { CandlePeriod } from '@/types/chart';
+
+type ChartSelector = {
+	activePeriods: CandlePeriod;
+	handleActivePeriod: (period: CandlePeriod) => void;
+};
+
+function ChartSelector({ activePeriods, handleActivePeriod }: ChartSelector) {
+	const PERIODS: { label: string; id: CandlePeriod }[] = [
+		{
+			label: '일',
+			id: 'days',
+		},
+		{
+			label: '주',
+			id: 'weeks',
+		},
+		{
+			label: '월',
+			id: 'months',
+		},
+		{
+			label: '년',
+			id: 'years',
+		},
+	];
+
+	return (
+		<div className="text-sm flex gap-6 py-2 pl-3 items-center">
+			<span className="font-semibold text-gray-900">차트</span>
+			<div className="flex gap-3">
+				{PERIODS.map(({ label, id }) => (
+					<button
+						key={id}
+						className={`text-gray-900 py-1 px-3 rounded-md ${activePeriods === id ? 'bg-gray-300' : ''} hover:bg-gray-200`}
+						onClick={() => handleActivePeriod(id)}
+					>
+						{label}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}
+
+export default ChartSelector;

--- a/packages/client/src/pages/trade/components/chart/ChartSkeleton.tsx
+++ b/packages/client/src/pages/trade/components/chart/ChartSkeleton.tsx
@@ -1,0 +1,5 @@
+function ChartSkeleton() {
+	return <div className="bg-gray-50 w-2/3 rounded-lg min-w-96"></div>;
+}
+
+export default ChartSkeleton;

--- a/packages/client/src/pages/trade/components/chart/chartSetup.ts
+++ b/packages/client/src/pages/trade/components/chart/chartSetup.ts
@@ -1,0 +1,34 @@
+// src/components/Chart/utils/chartSetup.ts
+import { IChartApi, createChart, ISeriesApi } from 'lightweight-charts';
+import { CandleFormat } from '@/types/chart';
+import { ChartConfig } from '@/pages/trade/components/chart/config';
+
+export const initializeChart = (
+	container: HTMLElement,
+	config: ChartConfig,
+): IChartApi => {
+	const chart = createChart(container, config.chartOptions);
+
+	chart.timeScale().applyOptions({
+		borderColor: '#1111',
+	});
+
+	return chart;
+};
+
+export const setupCandlestickSeries = (
+	chart: IChartApi,
+	data: CandleFormat[],
+	config: ChartConfig,
+): ISeriesApi<'Candlestick'> => {
+	const candlestickSeries = chart.addCandlestickSeries();
+
+	candlestickSeries.priceScale().applyOptions({
+		borderColor: '#1111',
+	});
+
+	candlestickSeries.applyOptions(config.candleStickOptions);
+	candlestickSeries.setData(data);
+
+	return candlestickSeries;
+};

--- a/packages/client/src/pages/trade/components/chart/config.ts
+++ b/packages/client/src/pages/trade/components/chart/config.ts
@@ -1,0 +1,31 @@
+import {
+	ChartOptions,
+	CandlestickSeriesOptions,
+	DeepPartial,
+} from 'lightweight-charts';
+
+export interface ChartConfig {
+	chartOptions: DeepPartial<ChartOptions>;
+	candleStickOptions: DeepPartial<CandlestickSeriesOptions>;
+}
+export const chartConfig = {
+	chartOptions: {
+		height: 600,
+		layout: {
+			background: { color: '#F9FAFB' },
+			textColor: '#243c5a',
+			fontFamily: "'Pretendard', sans-serif",
+		},
+		grid: {
+			vertLines: { color: '#1111' },
+			horzLines: { color: '#1111' },
+		},
+	},
+	candleStickOptions: {
+		wickUpColor: 'rgb(225, 50, 85)',
+		upColor: 'rgb(225, 50, 85)',
+		wickDownColor: 'rgb(54, 116, 217)',
+		downColor: 'rgb(54, 116, 217)',
+		borderVisible: false,
+	},
+};

--- a/packages/client/src/pages/trade/components/order_form/OrderForm.tsx
+++ b/packages/client/src/pages/trade/components/order_form/OrderForm.tsx
@@ -39,7 +39,7 @@ function OrderForm({ currentPrice }: { currentPrice: number }) {
 	];
 
 	return (
-		<div className="bg-gray-50 w-1/3 min-w-96 rounded-lg p-2">
+		<div className="bg-gray-50 flex-1 rounded-lg p-2 min-w-80">
 			<div className="text-sm font-semibold">주문하기</div>
 			<Tabs value={TABS[0].value}>
 				<TabsHeader className="w-full flex bg-gray-200 rounded-lg mt-3">

--- a/packages/client/src/pages/trade/components/trade_header/CoinInfo.tsx
+++ b/packages/client/src/pages/trade/components/trade_header/CoinInfo.tsx
@@ -8,7 +8,7 @@ type CoinInfoProps = {
 	trade_price: string;
 	change_price: string;
 	change_rate: string;
-	coin_img_url: string;
+	image_url: string;
 };
 
 function CoinInfo({
@@ -18,11 +18,11 @@ function CoinInfo({
 	trade_price,
 	change_price,
 	change_rate,
-	coin_img_url,
+	image_url,
 }: CoinInfoProps) {
 	return (
 		<div className="flex gap-2">
-			<img className="w-10 h-10" src={coin_img_url} />
+			<img className="w-10 h-10" src={image_url} />
 			<div>
 				<div>
 					<span className="pr-1">{korean_name}</span>

--- a/packages/client/src/pages/trade/components/trade_header/TradeHeader.tsx
+++ b/packages/client/src/pages/trade/components/trade_header/TradeHeader.tsx
@@ -27,8 +27,8 @@ function TradeHeader({ market, sseData }: TradeHeaderProps) {
 
 	const high_price = sseData[market].high_price.toLocaleString();
 	const low_price = sseData[market].low_price.toLocaleString();
-	const korean_name = sseData[market].name;
-	const coin_img_url = sseData[market].coin_img_url;
+	const korean_name = sseData[market].korean_name;
+	const image_url = sseData[market].image_url;
 
 	return (
 		<div className="w-full flex justify-between mb-3">
@@ -39,7 +39,7 @@ function TradeHeader({ market, sseData }: TradeHeaderProps) {
 				trade_price={trade_price}
 				change_price={change_price}
 				change_rate={change_rate}
-				coin_img_url={coin_img_url}
+				image_url={image_url}
 			/>
 			<CoinStats
 				acc_trade_price_24h={acc_trade_price_24h}

--- a/packages/client/src/types/chart.ts
+++ b/packages/client/src/types/chart.ts
@@ -1,0 +1,25 @@
+export type Candle = {
+	market: string;
+	candle_date_time_utc: string;
+	candle_date_time_kst: string;
+	opening_price: number;
+	high_price: number;
+	low_price: number;
+	trade_price: number;
+	timestamp: number;
+	candle_acc_trade_price: number;
+	candle_acc_trade_volume: number;
+	prev_closing_price: number;
+	change_price: number;
+	change_rate: number;
+};
+
+export type CandleFormat = {
+	time: string;
+	open: number;
+	high: number;
+	low: number;
+	close: number;
+};
+
+export type CandlePeriod = 'days' | 'weeks' | 'months' | 'years';

--- a/packages/client/src/types/ticker.ts
+++ b/packages/client/src/types/ticker.ts
@@ -1,8 +1,8 @@
 export type Change = 'RISE' | 'FALL' | 'EVEN';
 
 type CoinTicker = {
-	name: string;
-	coin_img_url: string;
+	korean_name: string;
+	image_url: string;
 	type: string;
 	code: string;
 	opening_price: number;

--- a/packages/client/src/utility/formatCandleData.ts
+++ b/packages/client/src/utility/formatCandleData.ts
@@ -1,0 +1,13 @@
+import { Candle, CandleFormat } from '@/types/chart';
+
+export function formatCandleData(data: Candle[]): CandleFormat[] {
+	return data
+		.map((candle) => ({
+			time: candle.candle_date_time_utc.split('T')[0],
+			open: candle.opening_price,
+			high: candle.high_price,
+			low: candle.low_price,
+			close: candle.trade_price,
+		}))
+		.reverse();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3620,6 +3620,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-react-refresh: "npm:^0.4.13"
     globals: "npm:^15.11.0"
+    lightweight-charts: "npm:^4.2.1"
     lottie-react: "npm:^2.4.0"
     postcss: "npm:^8.4.47"
     react: "npm:^18.3.1"
@@ -4773,6 +4774,13 @@ __metadata:
     iconv-lite: "npm:^0.4.24"
     tmp: "npm:^0.0.33"
   checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
+"fancy-canvas@npm:2.1.0":
+  version: 2.1.0
+  resolution: "fancy-canvas@npm:2.1.0"
+  checksum: 10c0/2b863b1548214ac793a5104154be389dbca6847c53c8bda88e4309f14bcdb498f4da21e368b573f3ab5f458d3b47c3f0ef731a7b90c8264b23c1cf0bfc9d1da3
   languageName: node
   linkType: hard
 
@@ -6467,6 +6475,15 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"lightweight-charts@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "lightweight-charts@npm:4.2.1"
+  dependencies:
+    fancy-canvas: "npm:2.1.0"
+  checksum: 10c0/727f19cea545dae23ecbc42182181fdf5f1978382f3dcdaaea70cbbf8368dba797dd535f29c272bd754f24cc97258490d5ac86c1360ad168e83a2005b167c7be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## ✅ 작업 내용

- 차트 light-weight 라이브러리 적용
- [lightweight-charts](https://www.tradingview.com/lightweight-charts/)

- upbit  캔들 데이터 조회 api 정의(일/주/월/년)
- 캔들 데이터 조회  api `useSuspenseQuery`커스텀 훅으로 분리(`usePeriodChart`)
- 차트 일/주/월/년 봉으로 선택하여 볼 수 있는 `ChartSelector`정의
    - 기본 상태는 일봉이 기본 선택 상태입니다
- 차트 크기 반응형으로 구현

## 📸 스크린샷(FE만)

https://github.com/user-attachments/assets/e1912a70-3df6-4cf9-a4ca-b3736e19b6a4

## 📌 이슈 사항

- 현재 차트 크기의 반응형을 구현하며 파일 분리를 하지 못한 상태입니다. 추후 로직 분리가 필요한 상태라고 판단 됩니다.
- 현재 한 번에 가져올 수 있는 candle 데이터의 양이 200개로 200개의 캔들 데이터만 보여주고 있습니다. 추후 차트 스크롤 시 캔들 데이터가 존재하지 않는다면 데이터를 더 요청하는 로직이 추가되어야 할 것 같습니다.

## 🟢 완료 조건

## ✍ 궁금한 점

- 현재 차트와 관련된 설정 파일들의(chartSetup.ts, config.ts) 위치를 pages→trade→components→chart 의 경로로 두었는데 파일 위치가 마음에 들지 않네요… 적절한 파일 위치가 떠오르신다면 말씀해주시면 좋을 것 같습니다!