### PR TITLE
[FE] - feature#7 사이드 바 실시간 기능 구현

### DIFF
--- a/packages/client/src/api/coin.ts
+++ b/packages/client/src/api/coin.ts
@@ -1,9 +1,14 @@
 import { instance } from '@/api/instance';
 import { Candle, CandlePeriod } from '@/types/chart';
-import { MarketData } from '@/types/market';
+import { MarketData, MarketTop20Data } from '@/types/market';
 
 export async function getMarketAll(): Promise<MarketData[]> {
-	const response = await instance.get('/market/all?is_details=true');
+	const response = await instance.get('/upbit/market/all');
+	return response.data;
+}
+
+export async function getMarketTop20(): Promise<MarketTop20Data[]> {
+	const response = await instance.get('upbit/market/top20-trade/krw');
 	return response.data;
 }
 

--- a/packages/client/src/api/coin.ts
+++ b/packages/client/src/api/coin.ts
@@ -1,4 +1,4 @@
-import { instance } from '@/api/instance';
+import { instance,upbitInstance } from '@/api/instance';
 import { Candle, CandlePeriod } from '@/types/chart';
 import { MarketData, MarketTop20Data } from '@/types/market';
 
@@ -16,7 +16,7 @@ export async function getCandleByPeriod(
 	market: string,
 	params: CandlePeriod,
 ): Promise<Candle[]> {
-	const response = await instance.get(`/candles/${params}`, {
+	const response = await upbitInstance.get(`/candles/${params}`, {
 		params: {
 			market,
 			count: 200,

--- a/packages/client/src/api/instance.ts
+++ b/packages/client/src/api/instance.ts
@@ -4,3 +4,8 @@ export const instance = axios.create({
 	baseURL: ' http://175.106.98.147:3000',
 	timeout: 2000,
 });
+
+export const upbitInstance = axios.create({
+	baseURL: ' https://api.upbit.com/v1',
+	timeout: 2000,
+});

--- a/packages/client/src/api/instance.ts
+++ b/packages/client/src/api/instance.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-	baseURL: ' https://api.upbit.com/v1',
+	baseURL: ' http://175.106.98.147:3000',
 	timeout: 2000,
 });
-

--- a/packages/client/src/components/NotLogin.tsx
+++ b/packages/client/src/components/NotLogin.tsx
@@ -20,7 +20,7 @@ function NotLogin({ size }: NotLoginProps) {
 	const sizeTable: SizeTable = {
 		sm: {
 			animationCss: 'w-40 h-40 md:w-52 md:h-52',
-			mainText: 'font-semibold text-lg text-gray-800 leading-relaxed',
+			mainText: 'font-semibold text-sm text-gray-800 leading-relaxed',
 			subText: 'text-xs text-gray-500',
 		},
 		md: {

--- a/packages/client/src/components/NotLogin.tsx
+++ b/packages/client/src/components/NotLogin.tsx
@@ -20,8 +20,8 @@ function NotLogin({ size }: NotLoginProps) {
 	const sizeTable: SizeTable = {
 		sm: {
 			animationCss: 'w-40 h-40 md:w-52 md:h-52',
-			mainText: 'font-semibold text-sm text-gray-800 leading-relaxed',
-			subText: 'text-xs text-gray-500',
+			mainText: 'font-semibold text-base text-gray-800 leading-relaxed',
+			subText: 'text-sm text-gray-500',
 		},
 		md: {
 			animationCss: 'w-52 h-52 md:w-64 md:h-64',
@@ -45,7 +45,7 @@ function NotLogin({ size }: NotLoginProps) {
 			/>
 			<div className="text-center space-y-2">
 				<div className={sizeTable[size].mainText}>
-					로그인 후 사용 가능한 서비스에요!
+					로그인 후 사용 가능한 서비스에요 !
 				</div>
 				<p className={sizeTable[size].subText}>
 					서비스 이용을 위해 로그인해 주세요

--- a/packages/client/src/components/sidebar/Interest.tsx
+++ b/packages/client/src/components/sidebar/Interest.tsx
@@ -1,5 +1,7 @@
+import NotLogin from "@/components/NotLogin";
+
 function Interest() {
-	return <div>Interest</div>;
+	return <div><NotLogin size="sm"/></div>;
 }
 
 export default Interest;

--- a/packages/client/src/components/sidebar/Interest.tsx
+++ b/packages/client/src/components/sidebar/Interest.tsx
@@ -1,0 +1,5 @@
+function Interest() {
+	return <div>Interest</div>;
+}
+
+export default Interest;

--- a/packages/client/src/components/sidebar/MyInvestment.tsx
+++ b/packages/client/src/components/sidebar/MyInvestment.tsx
@@ -1,0 +1,5 @@
+function MyInvestment() {
+	return <div>MyInvestment</div>;
+}
+
+export default MyInvestment;

--- a/packages/client/src/components/sidebar/MyInvestment.tsx
+++ b/packages/client/src/components/sidebar/MyInvestment.tsx
@@ -1,5 +1,7 @@
+import NotLogin from "@/components/NotLogin";
+
 function MyInvestment() {
-	return <div>MyInvestment</div>;
+	return <div><NotLogin size="sm"/></div>;
 }
 
 export default MyInvestment;

--- a/packages/client/src/components/sidebar/Realtime.tsx
+++ b/packages/client/src/components/sidebar/Realtime.tsx
@@ -1,0 +1,5 @@
+function Realtime() {
+	return <div>Realtime</div>;
+}
+
+export default Realtime;

--- a/packages/client/src/components/sidebar/Realtime.tsx
+++ b/packages/client/src/components/sidebar/Realtime.tsx
@@ -7,10 +7,9 @@ import { formatData } from '@/utility/formatData';
 function Realtime() {
 	const { data: top20List } = useMarketTop20();
 	const currentTime = useCurrentTime();
-	const { sseData } = useSSETicker(top20List);
-	if(!sseData || !top20List) return 
+	const { sseData } = useSSETicker(top20List || []);
+	if (!sseData || !top20List) return;
 	const formatters = formatData('KRW');
-
 
 	return (
 		<div className="flex flex-col h-full overflow-y-auto [&::-webkit-scrollbar]:hidden p-4">
@@ -25,7 +24,7 @@ function Realtime() {
 				<SidebarCoin
 					key={coin.market}
 					listNumber={index + 1}
-					formatters= {formatters}
+					formatters={formatters}
 					sseData={sseData}
 					{...coin}
 				/>

--- a/packages/client/src/components/sidebar/Realtime.tsx
+++ b/packages/client/src/components/sidebar/Realtime.tsx
@@ -1,5 +1,37 @@
+import SidebarCoin from '@/components/sidebar/SidebarCoin';
+import { useCurrentTime } from '@/hooks/useCurrentTIme';
+import { useMarketTop20 } from '@/hooks/useMarketTop20';
+import { useSSETicker } from '@/hooks/useSSETicker';
+import { formatData } from '@/utility/formatData';
+
 function Realtime() {
-	return <div>Realtime</div>;
+	const { data: top20List } = useMarketTop20();
+	const currentTime = useCurrentTime();
+	const { sseData } = useSSETicker(top20List);
+	if(!sseData || !top20List) return 
+	const formatters = formatData('KRW');
+
+
+	return (
+		<div className="flex flex-col h-full overflow-y-auto [&::-webkit-scrollbar]:hidden p-4">
+			<div>
+				<span className="text-lg font-semibold">실시간 차트</span>
+				<span className="ml-2 text-xs text-gray-700">
+					오늘 {currentTime} 기준
+				</span>
+			</div>
+			<div className="border border-solid border-gray-300 my-3"></div>
+			{top20List?.map((coin, index) => (
+				<SidebarCoin
+					key={coin.market}
+					listNumber={index + 1}
+					formatters= {formatters}
+					sseData={sseData}
+					{...coin}
+				/>
+			))}
+		</div>
+	);
 }
 
 export default Realtime;

--- a/packages/client/src/components/sidebar/RecentlyViewed.tsx
+++ b/packages/client/src/components/sidebar/RecentlyViewed.tsx
@@ -1,5 +1,7 @@
+import NotLogin from "@/components/NotLogin";
+
 function RecentlyViewed() {
-	return <div>RecentlyViewed</div>;
+	return <div><NotLogin size="sm"/></div>;
 }
 
 export default RecentlyViewed;

--- a/packages/client/src/components/sidebar/RecentlyViewed.tsx
+++ b/packages/client/src/components/sidebar/RecentlyViewed.tsx
@@ -1,0 +1,5 @@
+function RecentlyViewed() {
+	return <div>RecentlyViewed</div>;
+}
+
+export default RecentlyViewed;

--- a/packages/client/src/components/sidebar/SideDrawer.tsx
+++ b/packages/client/src/components/sidebar/SideDrawer.tsx
@@ -10,7 +10,6 @@ type SideDrawerProps = {
 };
 
 function SideDrawer({ isOpen, activeMenu }: SideDrawerProps) {
-	if (!activeMenu) return;
 
 	const activeMenuComponent = {
 		MY_INVESTMENT: <MyInvestment />,
@@ -30,7 +29,7 @@ function SideDrawer({ isOpen, activeMenu }: SideDrawerProps) {
             ${isOpen ? 'translate-x-0 w-64' : 'translate-x-full w-0'}
           `}
 			>
-				{activeMenuComponent[activeMenu]}
+				{activeMenu && activeMenuComponent[activeMenu]}
 			</div>
 		</div>
 	);

--- a/packages/client/src/components/sidebar/SideDrawer.tsx
+++ b/packages/client/src/components/sidebar/SideDrawer.tsx
@@ -1,4 +1,24 @@
-function SideDrawer({ isOpen }: { isOpen: boolean }) {
+import Interest from '@/components/sidebar/Interest';
+import MyInvestment from '@/components/sidebar/MyInvestment';
+import Realtime from '@/components/sidebar/Realtime';
+import RecentlyViewed from '@/components/sidebar/RecentlyViewed';
+import { SideBarMenu } from '@/types/menu';
+
+type SideDrawerProps = {
+	isOpen: boolean;
+	activeMenu: SideBarMenu;
+};
+
+function SideDrawer({ isOpen, activeMenu }: SideDrawerProps) {
+	if (!activeMenu) return;
+
+	const activeMenuComponent = {
+		MY_INVESTMENT: <MyInvestment />,
+		INTEREST: <Interest />,
+		RECENTLY_VIEWED: <RecentlyViewed />,
+		REALTIME: <Realtime />,
+	};
+	
 	return (
 		<div className="overflow-hidden ">
 			<div
@@ -9,7 +29,9 @@ function SideDrawer({ isOpen }: { isOpen: boolean }) {
 			border-l border-gray-400 border-solid
             ${isOpen ? 'translate-x-0 w-64' : 'translate-x-full w-0'}
           `}
-			></div>
+			>
+				{activeMenuComponent[activeMenu]}
+			</div>
 		</div>
 	);
 }

--- a/packages/client/src/components/sidebar/SideDrawer.tsx
+++ b/packages/client/src/components/sidebar/SideDrawer.tsx
@@ -26,7 +26,7 @@ function SideDrawer({ isOpen, activeMenu }: SideDrawerProps) {
             bg-gray-100
             transition-all duration-300 ease-in-out
 			border-l border-gray-400 border-solid
-            ${isOpen ? 'translate-x-0 w-64' : 'translate-x-full w-0'}
+            ${isOpen ? 'translate-x-0 w-80' : 'translate-x-full w-0'}
           `}
 			>
 				{activeMenu && activeMenuComponent[activeMenu]}

--- a/packages/client/src/components/sidebar/Sidebar.tsx
+++ b/packages/client/src/components/sidebar/Sidebar.tsx
@@ -47,7 +47,7 @@ function Sidebar() {
 	return (
 		<div className="flex bg-gray-100 h-screen sticky top-0">
 			<SideDrawer isOpen={isOpen} activeMenu={activeMenu} />
-			<div className="w-20 flex flex-col gap-3 items-center border-l border-gray-400 border-solid">
+			<div className="w-14 flex flex-col gap-3 items-center border-l border-gray-400 border-solid">
 				{SIDEBAR_BUTTONS.map((button) => (
 					<SideBarButton
 						key={button.id}

--- a/packages/client/src/components/sidebar/Sidebar.tsx
+++ b/packages/client/src/components/sidebar/Sidebar.tsx
@@ -8,12 +8,13 @@ import useSideDraw from '@/hooks/useSideDraw';
 import { SideBarMenu } from '@/types/menu';
 
 function Sidebar() {
-	const { isOpen, handleMenu } = useSideDraw();
+	const { activeMenu, isOpen, handleMenu } = useSideDraw();
 
 	type SideBarButtons = {
 		id: string;
 		icons: JSX.Element;
-		text: SideBarMenu;
+		text: string;
+		active: SideBarMenu
 	};
 
 	const SIDEBAR_BUTTONS: SideBarButtons[] = [
@@ -21,33 +22,38 @@ function Sidebar() {
 			id: 'invest',
 			icons: <Invest />,
 			text: '내 투자',
+			active: 'MY_INVESTMENT',
 		},
 		{
 			id: 'heart',
 			icons: <Heart />,
 			text: '관심',
+			active: 'INTEREST'
 		},
 		{
 			id: 'calendar',
 			icons: <Calendar />,
 			text: '최근 본',
+			active: 'RECENTLY_VIEWED'
 		},
 		{
 			id: 'fire',
 			icons: <Fire />,
 			text: '실시간',
+			active: 'REALTIME'
 		},
 	];
 
 	return (
 		<div className="flex bg-gray-100 h-screen sticky top-0">
-			<SideDrawer isOpen={isOpen} />
+			<SideDrawer isOpen={isOpen} activeMenu={activeMenu} />
 			<div className="w-20 flex flex-col gap-3 items-center border-l border-gray-400 border-solid">
 				{SIDEBAR_BUTTONS.map((button) => (
 					<SideBarButton
 						key={button.id}
 						icons={button.icons}
 						text={button.text}
+						active={button.active}
 						handleMenu={handleMenu}
 					/>
 				))}

--- a/packages/client/src/components/sidebar/SidebarButton.tsx
+++ b/packages/client/src/components/sidebar/SidebarButton.tsx
@@ -3,17 +3,18 @@ import React from 'react';
 
 type SidBarButtonProps = {
 	icons: JSX.Element;
-	text: SideBarMenu;
+	text: string;
+	active: SideBarMenu
 	handleMenu: (menu: SideBarMenu) => void;
 };
 
-function SideBarButton({ icons, text, handleMenu }: SidBarButtonProps) {
+function SideBarButton({ icons, text, handleMenu, active }: SidBarButtonProps) {
 	const activeMenu = localStorage.getItem('side-menu');
-	const isActive = activeMenu === text;
+	const isActive = activeMenu === active;
 	return (
 		<div
 			className="group flex flex-col items-center gap-2 py-2 cursor-pointer"
-			onClick={() => handleMenu(text)}
+			onClick={() => handleMenu(active)}
 		>
 			<button className="text-white rounded p-1 group-hover:bg-gray-300">
 				{React.cloneElement(icons, {

--- a/packages/client/src/components/sidebar/SidebarCoin.tsx
+++ b/packages/client/src/components/sidebar/SidebarCoin.tsx
@@ -40,7 +40,7 @@ function SidebarCoin({
 			<div className="flex flex-col items-end">
 				<span className="text-base font-semibold">{`${trade_price}`}</span>
 				<span className={`text-xs font-medium ${colorClasses[change]}`}>
-					{change_price}({change_rate})
+					{change_price} {change_rate}
 				</span>
 			</div>
 		</div>

--- a/packages/client/src/components/sidebar/SidebarCoin.tsx
+++ b/packages/client/src/components/sidebar/SidebarCoin.tsx
@@ -1,0 +1,50 @@
+import colorClasses from '@/constants/priceColor';
+import { Change, SSEDataType } from '@/types/ticker';
+import { Formatters } from '@/utility/formatData';
+
+type SidebarCoinProps = {
+	image_url: string;
+	korean_name: string;
+	listNumber: number;
+	formatters: Formatters;
+	sseData: SSEDataType;
+	market: string;
+};
+
+function SidebarCoin({
+	listNumber,
+	image_url,
+	korean_name,
+	formatters,
+	sseData,
+	market,
+}: SidebarCoinProps) {
+	const change: Change = sseData[market]?.change;
+
+	const trade_price = formatters.formatTradePrice(sseData[market]?.trade_price);
+	const change_rate = formatters.formatChangeRate(
+		sseData[market]?.signed_change_rate,
+		change,
+	);
+	const change_price = formatters.formatSignedChangePrice(
+		sseData[market]?.signed_change_price,
+		change,
+	);
+	return (
+		<div className="flex items-center py-2 px-1 gap-2">
+			<span className="text-base font-medium text-blue-700">{listNumber}</span>
+			<img className="w-8 -h-8" src={image_url}></img>
+			<span className="text-sm flex-[1] text-gray-800 font-semibold">
+				{korean_name}
+			</span>
+			<div className="flex flex-col items-end">
+				<span className="text-base font-semibold">{`${trade_price}`}</span>
+				<span className={`text-xs font-medium ${colorClasses[change]}`}>
+					{change_price}({change_rate})
+				</span>
+			</div>
+		</div>
+	);
+}
+
+export default SidebarCoin;

--- a/packages/client/src/components/sidebar/SidebarCoin.tsx
+++ b/packages/client/src/components/sidebar/SidebarCoin.tsx
@@ -1,6 +1,7 @@
 import colorClasses from '@/constants/priceColor';
 import { Change, SSEDataType } from '@/types/ticker';
 import { Formatters } from '@/utility/formatData';
+import { Link } from 'react-router-dom';
 
 type SidebarCoinProps = {
 	image_url: string;
@@ -31,19 +32,23 @@ function SidebarCoin({
 		change,
 	);
 	return (
-		<div className="flex items-center py-2 px-1 gap-2">
-			<span className="text-base font-medium text-blue-700">{listNumber}</span>
-			<img className="w-8 -h-8" src={image_url}></img>
-			<span className="text-sm flex-[1] text-gray-800 font-semibold">
-				{korean_name}
-			</span>
-			<div className="flex flex-col items-end">
-				<span className="text-base font-semibold">{`${trade_price}`}</span>
-				<span className={`text-xs font-medium ${colorClasses[change]}`}>
-					{change_price} {change_rate}
+		<Link to={`/trade/${market}`}> 
+			<div className="flex items-center py-2 px-1 gap-2 hover:bg-gray-200 border rounded-lg cursor-pointer">
+				<span className="text-base font-medium text-blue-700">
+					{listNumber}
 				</span>
+				<img className="w-8 -h-8" src={image_url}></img>
+				<span className="text-sm flex-[1] text-gray-800 font-semibold">
+					{korean_name}
+				</span>
+				<div className="flex flex-col items-end">
+					<span className="text-base font-semibold">{`${trade_price}`}</span>
+					<span className={`text-xs font-medium ${colorClasses[change]}`}>
+						{change_price} {change_rate}
+					</span>
+				</div>
 			</div>
-		</div>
+		</Link>
 	);
 }
 

--- a/packages/client/src/hooks/useCurrentTIme.ts
+++ b/packages/client/src/hooks/useCurrentTIme.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+export function useCurrentTime() {
+	const [currentTime, setCurrentTime] = useState('');
+
+	useEffect(() => {
+		const updateCurrentTime = () => {
+			const now = new Date();
+
+			setCurrentTime(
+				now.toLocaleTimeString('ko-KR', {
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: false, // 24시간 형식으로 설정
+				}),
+			);
+		};
+
+		// 초기 시간 설정 및 1분마다 갱신
+		updateCurrentTime();
+		const timer = setInterval(updateCurrentTime, 60000);
+
+		return () => clearInterval(timer);
+	}, []);
+
+	return currentTime;
+}

--- a/packages/client/src/hooks/useMarketTop20.ts
+++ b/packages/client/src/hooks/useMarketTop20.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMarketTop20 } from '@/api/coin';
+
+export function useMarketTop20() {
+	const { isPending, error, data } = useQuery({
+		queryKey: ['marketTop20'],
+		queryFn: getMarketTop20,
+		staleTime: 1000 * 60, // 1분
+		gcTime: 1000 * 60 * 5, // 5분
+	});
+
+	return { isPending, error, data };
+}

--- a/packages/client/src/hooks/useSSETicker.ts
+++ b/packages/client/src/hooks/useSSETicker.ts
@@ -7,6 +7,7 @@ export function useSSETicker(targetMarketCodes: { market: string }[]) {
 	const [sseData, setSSEData] = useState<SSEDataType | null>();
 
 	useEffect(() => {
+		if (!targetMarketCodes?.length) return; // early return 추가
 		const queryString = targetMarketCodes
 			.map((code) => `coins=${encodeURIComponent(code.market)}`)
 			.join('&');

--- a/packages/client/src/hooks/useSSETicker.ts
+++ b/packages/client/src/hooks/useSSETicker.ts
@@ -1,5 +1,6 @@
 import { SSEDataType } from '@/types/ticker';
 import { useEffect, useRef, useState } from 'react';
+
 export function useSSETicker(targetMarketCodes: { market: string }[]) {
 	const BASE_URL = 'http://175.106.98.147:3000/upbit/price-updates';
 	const eventSource = useRef<EventSource | null>(null);

--- a/packages/client/src/pages/home/components/Coin.tsx
+++ b/packages/client/src/pages/home/components/Coin.tsx
@@ -54,7 +54,7 @@ function Coin({ formatters, market, sseData }: CoinProps) {
 			<div className="flex-[6]">
 				<div className={colorClasses[change]}>
 					<span className="block">
-						{change_rate} ({change_price})
+					{change_price}({change_rate})
 					</span>
 				</div>
 			</div>

--- a/packages/client/src/pages/home/components/Coin.tsx
+++ b/packages/client/src/pages/home/components/Coin.tsx
@@ -54,7 +54,7 @@ function Coin({ formatters, market, sseData }: CoinProps) {
 			<div className="flex-[6]">
 				<div className={colorClasses[change]}>
 					<span className="block">
-					{change_price}({change_rate})
+					{change_price} {change_rate}
 					</span>
 				</div>
 			</div>

--- a/packages/client/src/pages/trade/components/trade_header/TradeHeader.tsx
+++ b/packages/client/src/pages/trade/components/trade_header/TradeHeader.tsx
@@ -9,7 +9,9 @@ type TradeHeaderProps = {
 };
 
 function TradeHeader({ market, sseData }: TradeHeaderProps) {
+	if (!sseData[market]) return; // 임시 방편 처리
 	const formatter = formatData('KRW');
+
 	const code = sseData[market].code;
 	const trade_price = sseData[market].trade_price.toLocaleString();
 	const change = sseData[market].change;

--- a/packages/client/src/types/market.ts
+++ b/packages/client/src/types/market.ts
@@ -15,3 +15,9 @@ export type MarketData = {
 	market_warning?: string;
 	market_event: { warning: boolean; caution: MarketEvent };
 };
+
+export type MarketTop20Data = {
+	market: string;
+	korean_name: string;
+	image_url:string
+}

--- a/packages/client/src/types/menu.ts
+++ b/packages/client/src/types/menu.ts
@@ -1,4 +1,5 @@
 import { Market } from '@/types/market';
 
-export type SideBarMenu = '실시간' | '관심' | '내 투자' | '최근 본' | null;
+export type SideBarMenu = 'MY_INVESTMENT' | 'INTEREST' | 'RECENTLY_VIEWED' | 'REALTIME' | null;
+
 export type MarketCategory = Market | 'INTEREST' | 'OWN';

--- a/packages/client/src/utility/formatData.ts
+++ b/packages/client/src/utility/formatData.ts
@@ -26,7 +26,7 @@ export const formatData = (category: MarketCategory) => {
 			};
 
 			formatters.formatChangeRate = (price: number, change: Change) =>
-				`${decideSign(change) + (Number(price) * 100).toFixed(2)}%`;
+				`(${decideSign(change) + (Number(price) * 100).toFixed(2)}%)`;
 
 			formatters.formatAccTradePrice = (price: number) =>
 				`${Math.floor(Number(price) / 1000000).toLocaleString()}백만`;


### PR DESCRIPTION
closes #7 

## ✅ 작업 내용
- 사이드바 실시간 탭 기능 구현
- 현재 시각 기준으로 거래량 순위 Top20 종목 실시간으로 보이게끔 구현
- 종목을 누를 시 trade 페이지로 이동되게 구현 


## 📸 스크린샷(FE만)
![chrome_zTGtc2njpK](https://github.com/user-attachments/assets/20b7b3b3-8ff0-4144-a7bd-caf7ac4e9422)

## 📌 이슈 사항
- 스크린샷 마지막 쯤에 trade 페이지에서 사이드바가 밀려서 크기가 짤리는 이슈가 있음.