### PR TITLE
[FE] - feature #70 - 체험용 로그인 구현

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "lightweight-charts": "^4.2.1",
     "lottie-react": "^2.4.0",
     "react": "^18.3.1",
+    "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "zustand": "^5.0.1"

--- a/packages/client/src/api/auth.ts
+++ b/packages/client/src/api/auth.ts
@@ -1,0 +1,8 @@
+import { instance } from '@/api/instance';
+
+export async function adminLogin() {
+	const response = await instance.post('/auth/login', {
+		username: 'admin',
+	});
+	return response.data;
+}

--- a/packages/client/src/api/auth.ts
+++ b/packages/client/src/api/auth.ts
@@ -1,8 +1,6 @@
 import { instance } from '@/api/instance';
 
-export async function adminLogin() {
-	const response = await instance.post('/auth/login', {
-		username: 'admin',
-	});
+export async function guestLogin() {
+	const response = await instance.post('/auth/guest-login');
 	return response.data;
 }

--- a/packages/client/src/api/instance.ts
+++ b/packages/client/src/api/instance.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 export const instance = axios.create({
 	baseURL: import.meta.env.VITE_API_BASE_URL,
+	withCredentials: true,
 	timeout: 2000,
 });
 

--- a/packages/client/src/components/Header.tsx
+++ b/packages/client/src/components/Header.tsx
@@ -1,7 +1,13 @@
+import { useAuth } from '@/hooks/useAuth';
 import { Button, Navbar } from '@material-tailwind/react';
 import { Link } from 'react-router-dom';
+import { useAuthStore } from '@/store/authStore';
 
 function Header() {
+	const { mutate } = useAuth();
+	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+	const logout = useAuthStore((state) => state.logout);
+
 	return (
 		<Navbar
 			fullWidth={true}
@@ -21,7 +27,14 @@ function Header() {
 				</Link>
 			</div>
 			<div>
-				<Button>로그인</Button>
+				{isAuthenticated ? (
+					<Button onClick={logout}>로그아웃</Button>
+				) : (
+					<>
+						<Button onClick={() => mutate()}>체험하기</Button>
+						<Button className="mx-2">로그인</Button>
+					</>
+				)}
 			</div>
 		</Navbar>
 	);

--- a/packages/client/src/components/NotLogin.tsx
+++ b/packages/client/src/components/NotLogin.tsx
@@ -1,5 +1,6 @@
 import Lottie from 'lottie-react';
 import BitcoinLottie from '@asset/lotties/BitcoinLottie.json';
+import { useAuth } from '@/hooks/useAuth';
 
 type Size = 'sm' | 'md' | 'lg';
 
@@ -13,6 +14,7 @@ type SizeTable = Record<
 		animationCss: string;
 		mainText: string;
 		subText: string;
+		highlightText: string;
 	}
 >;
 
@@ -22,18 +24,26 @@ function NotLogin({ size }: NotLoginProps) {
 			animationCss: 'w-40 h-40 md:w-52 md:h-52',
 			mainText: 'font-semibold text-base text-gray-800 leading-relaxed',
 			subText: 'text-sm text-gray-500',
+			highlightText:
+				'text-sm text-blue-500 font-medium cursor-pointer hover:underline',
 		},
 		md: {
 			animationCss: 'w-52 h-52 md:w-64 md:h-64',
 			mainText: 'font-semibold text-xl text-gray-800 leading-relaxed',
 			subText: 'text-sm text-gray-500',
+			highlightText:
+				'text-sm text-blue-500 font-medium cursor-pointer hover:underline',
 		},
 		lg: {
 			animationCss: 'w-64 h-64 md:w-72 md:h-72',
 			mainText: 'font-semibold text-2xl text-gray-800 leading-relaxed',
 			subText: 'text-base text-gray-500',
+			highlightText:
+				'text-base text-blue-500 font-medium cursor-pointer hover:underline',
 		},
 	};
+
+	const { mutate } = useAuth();
 
 	return (
 		<div className="w-full min-h-[50vh] flex flex-col justify-center items-center gap-6 p-6">
@@ -49,6 +59,9 @@ function NotLogin({ size }: NotLoginProps) {
 				</div>
 				<p className={sizeTable[size].subText}>
 					서비스 이용을 위해 로그인해 주세요
+				</p>
+				<p onClick={() => mutate()} className={sizeTable[size].highlightText}>
+					체험 계정으로 1초 만에 시작하기 →
 				</p>
 			</div>
 		</div>

--- a/packages/client/src/components/sidebar/Interest.tsx
+++ b/packages/client/src/components/sidebar/Interest.tsx
@@ -1,7 +1,10 @@
-import NotLogin from "@/components/NotLogin";
+import NotLogin from '@/components/NotLogin';
+import { useAuthStore } from '@/store/authStore';
 
 function Interest() {
-	return <div><NotLogin size="sm"/></div>;
+	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+	if (!isAuthenticated) return <NotLogin size="sm" />;
 }
 
 export default Interest;

--- a/packages/client/src/components/sidebar/MyInvestment.tsx
+++ b/packages/client/src/components/sidebar/MyInvestment.tsx
@@ -1,7 +1,9 @@
-import NotLogin from "@/components/NotLogin";
-
+import NotLogin from '@/components/NotLogin';
+import { useAuthStore } from '@/store/authStore';
 function MyInvestment() {
-	return <div><NotLogin size="sm"/></div>;
+	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+	if (!isAuthenticated) return <NotLogin size="sm" />;
 }
 
 export default MyInvestment;

--- a/packages/client/src/hooks/useAuth.ts
+++ b/packages/client/src/hooks/useAuth.ts
@@ -8,7 +8,10 @@ export function useAuth() {
 	const useAdminLogin = useMutation({
 		mutationFn: adminLogin,
 		onSuccess: ({ access_token }: { access_token: string }) => {
-			setCookie('access_token', access_token, { maxAge: 24 * 60 * 60 });
+			setCookie('access_token', access_token, {
+				path: '/',
+				maxAge: 24 * 60 * 60,
+			});
 			checkAuth();
 		},
 		onError: (error) => {

--- a/packages/client/src/hooks/useAuth.ts
+++ b/packages/client/src/hooks/useAuth.ts
@@ -1,0 +1,19 @@
+import { adminLogin } from '@/api/auth';
+import { useAuthStore } from '@/store/authStore';
+import { setCookie } from '@/utility/cookies';
+import { useMutation } from '@tanstack/react-query';
+
+export function useAuth() {
+	const checkAuth = useAuthStore((state) => state.checkAuth);
+	const useAdminLogin = useMutation({
+		mutationFn: adminLogin,
+		onSuccess: ({ access_token }: { access_token: string }) => {
+			setCookie('access_token', access_token, { maxAge: 24 * 60 * 60 });
+			checkAuth();
+		},
+		onError: (error) => {
+			console.error(error);
+		},
+	});
+	return useAdminLogin;
+}

--- a/packages/client/src/hooks/useAuth.ts
+++ b/packages/client/src/hooks/useAuth.ts
@@ -1,12 +1,12 @@
-import { adminLogin } from '@/api/auth';
+import { guestLogin } from '@/api/auth';
 import { useAuthStore } from '@/store/authStore';
 import { setCookie } from '@/utility/cookies';
 import { useMutation } from '@tanstack/react-query';
 
 export function useAuth() {
 	const checkAuth = useAuthStore((state) => state.checkAuth);
-	const useAdminLogin = useMutation({
-		mutationFn: adminLogin,
+	const useGuestLogin = useMutation({
+		mutationFn: guestLogin,
 		onSuccess: ({ access_token }: { access_token: string }) => {
 			setCookie('access_token', access_token, {
 				path: '/',
@@ -19,5 +19,5 @@ export function useAuth() {
 			console.error(error);
 		},
 	});
-	return useAdminLogin;
+	return useGuestLogin;
 }

--- a/packages/client/src/hooks/useAuth.ts
+++ b/packages/client/src/hooks/useAuth.ts
@@ -15,6 +15,7 @@ export function useAuth() {
 			checkAuth();
 		},
 		onError: (error) => {
+			alert(`로그인을 실패했습니다! ${error.message}`);
 			console.error(error);
 		},
 	});

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,13 +1,16 @@
 import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from '@/App';
 import { ThemeProvider } from '@material-tailwind/react';
 import { BrowserRouter } from 'react-router-dom';
+import { CookiesProvider } from 'react-cookie';
+import './index.css';
+import App from '@/App';
 
 createRoot(document.getElementById('root')!).render(
 	<ThemeProvider>
-		<BrowserRouter>
-			<App />
-		</BrowserRouter>
+		<CookiesProvider>
+			<BrowserRouter>
+				<App />
+			</BrowserRouter>
+		</CookiesProvider>
 	</ThemeProvider>,
 );

--- a/packages/client/src/pages/trade/components/order_form/OrderBuyForm.tsx
+++ b/packages/client/src/pages/trade/components/order_form/OrderBuyForm.tsx
@@ -2,10 +2,14 @@ import { useState } from 'react';
 import OrderInput from '@/pages/trade/components/order_form/common/OrderInput';
 import OrderSubmitButton from '@/pages/trade/components/order_form/common/OrderSubmitButton';
 import PercentageButtons from '@/pages/trade/components/order_form/common/PercentageButtons';
+import NotLogin from '@/components/NotLogin';
+import { useAuthStore } from '@/store/authStore';
 function OrderBuyForm({ currentPrice }: { currentPrice: number }) {
+	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 	const [price, setPrice] = useState(currentPrice);
 	const [quantity, setQuantity] = useState<number>(0);
 	const totalPrice = (price * quantity).toLocaleString();
+	if (!isAuthenticated) return <NotLogin size="md" />;
 	return (
 		<div className="text-black font-normal text-sm">
 			<form>

--- a/packages/client/src/pages/trade/components/order_form/OrderSellForm.tsx
+++ b/packages/client/src/pages/trade/components/order_form/OrderSellForm.tsx
@@ -2,13 +2,14 @@ import NotLogin from '@/components/NotLogin';
 import OrderInput from '@/pages/trade/components/order_form/common/OrderInput';
 import OrderSubmitButton from '@/pages/trade/components/order_form/common/OrderSubmitButton';
 import PercentageButtons from '@/pages/trade/components/order_form/common/PercentageButtons';
+import { useAuthStore } from '@/store/authStore';
 import { useState } from 'react';
 function OrderSellForm({ currentPrice }: { currentPrice: number }) {
-	const [isLogin] = useState(false);
+	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 	const [price, setPrice] = useState(currentPrice);
 	const [quantity, setQuantity] = useState<number>(0);
 	const totalPrice = (price * quantity).toLocaleString();
-	if (!isLogin) return <NotLogin size="md" />;
+	if (!isAuthenticated) return <NotLogin size="md" />;
 	return (
 		<div className="text-black font-normal text-sm">
 			<form>

--- a/packages/client/src/pages/trade/components/order_form/OrderWaitForm.tsx
+++ b/packages/client/src/pages/trade/components/order_form/OrderWaitForm.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
 import NotLogin from '@/components/NotLogin';
+import { useAuthStore } from '@/store/authStore';
 
 function OrderWaitForm() {
-	const [isLogin] = useState(false);
-	if (!isLogin) return <NotLogin size="md" />;
+	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+	if (!isAuthenticated) return <NotLogin size="md" />;
 	return <div>order wait</div>;
 }
 

--- a/packages/client/src/store/authStore.ts
+++ b/packages/client/src/store/authStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { getCookie, removeCookie } from '@/utility/cookies';
+interface AuthState {
+	isAuthenticated: boolean;
+	isLoading: boolean;
+	checkAuth: () => void;
+	logout: () => void;
+	getToken: () => string | null;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+	isAuthenticated: !!getCookie('access_token'),
+	isLoading: false,
+
+	checkAuth: () => {
+		const hasToken = !!getCookie('access_token');
+		set({ isAuthenticated: hasToken });
+	},
+
+	logout: () => {
+		removeCookie('access_token');
+		set({ isAuthenticated: false });
+	},
+
+	getToken: () => getCookie('access_token'),
+}));

--- a/packages/client/src/utility/cookies.ts
+++ b/packages/client/src/utility/cookies.ts
@@ -1,0 +1,29 @@
+import { Cookies } from 'react-cookie';
+
+interface CookieOptions {
+	path?: string;
+	expires?: Date;
+	maxAge?: number;
+	domain?: string;
+	secure?: boolean;
+	httpOnly?: boolean;
+	sameSite?: 'strict' | 'lax' | 'none';
+}
+
+const cookies = new Cookies();
+
+export function setCookie(
+	name: string,
+	value: string,
+	options?: CookieOptions,
+) {
+	return cookies.set(name, value, { ...options });
+}
+
+export function getCookie(name: string) {
+	return cookies.get(name);
+}
+
+export function removeCookie(name: string) {
+	return cookies.remove(name);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1994,6 +1994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookie@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@types/cookie@npm:0.6.0"
+  checksum: 10c0/5b326bd0188120fb32c0be086b141b1481fec9941b76ad537f9110e10d61ee2636beac145463319c71e4be67a17e85b81ca9e13ceb6e3bb63b93d16824d6c149
+  languageName: node
+  linkType: hard
+
 "@types/cookiejar@npm:^2.1.5":
   version: 2.1.5
   resolution: "@types/cookiejar@npm:2.1.5"
@@ -2074,6 +2081,16 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/235d2fc69741448e853333b7c3d1180a966dd2b8972c8cbcd6b2a0c6cd7f8d582ab2b8e58219dbc62cce8f1b40aa317ff78ea2201cdd8249da5025adebed6f0b
+  languageName: node
+  linkType: hard
+
+"@types/hoist-non-react-statics@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@types/hoist-non-react-statics@npm:3.3.5"
+  dependencies:
+    "@types/react": "npm:*"
+    hoist-non-react-statics: "npm:^3.3.0"
+  checksum: 10c0/2a3b64bf3d9817d7830afa60ee314493c475fb09570a64e7737084cd482d2177ebdddf888ce837350bac51741278b077683facc9541f052d4bbe8487b4e3e618
   languageName: node
   linkType: hard
 
@@ -3624,6 +3641,7 @@ __metadata:
     lottie-react: "npm:^2.4.0"
     postcss: "npm:^8.4.47"
     react: "npm:^18.3.1"
+    react-cookie: "npm:^7.2.2"
     react-dom: "npm:^18.3.1"
     react-router-dom: "npm:^6.27.0"
     tailwindcss: "npm:^3.4.14"
@@ -3826,6 +3844,13 @@ __metadata:
   version: 0.7.1
   resolution: "cookie@npm:0.7.1"
   checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
   languageName: node
   linkType: hard
 
@@ -5423,6 +5448,15 @@ __metadata:
   version: 10.7.3
   resolution: "highlight.js@npm:10.7.3"
   checksum: 10c0/073837eaf816922427a9005c56c42ad8786473dc042332dfe7901aa065e92bc3d94ebf704975257526482066abb2c8677cc0326559bb8621e046c21c5991c434
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
   languageName: node
   linkType: hard
 
@@ -7782,6 +7816,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-cookie@npm:^7.2.2":
+  version: 7.2.2
+  resolution: "react-cookie@npm:7.2.2"
+  dependencies:
+    "@types/hoist-non-react-statics": "npm:^3.3.5"
+    hoist-non-react-statics: "npm:^3.3.2"
+    universal-cookie: "npm:^7.0.0"
+  peerDependencies:
+    react: ">= 16.3.0"
+  checksum: 10c0/22948a42b986e22dad0817ffbad72fe52c907a9cd09c82e683807e21eb85ec82adb7b5121f9869bae418d589a05570a1e1043b3c930c293e3d94ddeaa98602e0
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:18.2.0":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
@@ -7806,7 +7853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -9366,6 +9413,16 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/cb811d9d54eb5821b81b18205750be84cb015c20a4a44280794e915f5a0a70223ce39066781a354e872df3572e8155c228f43ff0cce94c7cbf4da2cc7cbdd635
+  languageName: node
+  linkType: hard
+
+"universal-cookie@npm:^7.0.0":
+  version: 7.2.2
+  resolution: "universal-cookie@npm:7.2.2"
+  dependencies:
+    "@types/cookie": "npm:^0.6.0"
+    cookie: "npm:^0.7.2"
+  checksum: 10c0/214c5cf72b12b6d98a72e11a10adb3f1d06dbeadbd9a2d46ded8c288d86387e9ff25499f85d2f85728809484d678c02028ac674cb8747257b38d2c17fb93e896
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## ✅ 작업 내용
- closes #70 
- admin 계정 로그인 구현
-  로그인 상태 전역 상태로 관리
- 로그인 커스텀 훅 정의

## 📸 스크린샷(FE만)


## 📌 이슈 사항
- 로그인 access_token 을 관리하기 위해 cookie로 결정했습니다
- react-cookie 를 사용하여 라이브러리를 설치했으니 추후 merge 시 yarn install 부탁드립니다 ^^

## 🟢 완료 조건

## ✍ 궁금한 점
