### PR TITLE
refactor: 1원 이하인 코인은 가격이 소수점 5자리까지 보이게 모두 통일

### DIFF
--- a/packages/client/src/pages/account/balance/BalanceCoin.tsx
+++ b/packages/client/src/pages/account/balance/BalanceCoin.tsx
@@ -54,8 +54,8 @@ function BalanceCoin({ coin, sseData }: BalanceCoinProps) {
 			<div className="flex-[1] p-3 text-end">
 				<span className="text-base">
 					{averagePrice < 1
-						? averagePrice.toFixed(3)
-						: Math.floor(averagePrice).toLocaleString()}
+						? parseFloat(averagePrice.toFixed(5)).toString()
+						: averagePrice.toLocaleString()}
 				</span>
 				<span className="text-xs ml-1 text-gray-500">KRW</span>
 			</div>

--- a/packages/client/src/pages/account/history/HistoryInfo.tsx
+++ b/packages/client/src/pages/account/history/HistoryInfo.tsx
@@ -13,9 +13,8 @@ function HistoryInfo({
 	tradeDate,
 	tradeType,
 }: HistoryInfoProps) {
-
-	const formattedCreatedTime = formatDateTime(createdAt)
-	const formattedTradeTime = formatDateTime(tradeDate)
+	const formattedCreatedTime = formatDateTime(createdAt);
+	const formattedTradeTime = formatDateTime(tradeDate);
 
 	return (
 		<div className="flex py-2 items-center text-center  border-b border-solid border-gray-300">
@@ -24,10 +23,8 @@ function HistoryInfo({
 				<p>{formattedTradeTime.time}</p>
 			</div>
 			<div className="flex-[1] font-semibold">
-				<Link to={`/trade/KRW-${assetName}`}>
-				{assetName}
-				</Link>
-				</div>
+				<Link to={`/trade/KRW-${assetName}`}>{assetName}</Link>
+			</div>
 			<div
 				className={`flex-[1] ${tradeType === 'buy' ? 'text-red-500' : 'text-blue-500'}`}
 			>
@@ -38,7 +35,11 @@ function HistoryInfo({
 				<span className="ml-1 text-xs text-gray-600">{assetName}</span>
 			</div>
 			<div className="flex-[3]">
-				<span>{price.toLocaleString()}</span>
+				<span>
+					{price < 1
+						? parseFloat(price.toFixed(5)).toString()
+						: price.toLocaleString()}
+				</span>
 				<span className="ml-1 text-xs text-gray-600">{tradeCurrency}</span>
 			</div>
 			<div className="flex-[3]">

--- a/packages/client/src/pages/account/waitOrders/WaitOrderInfo.tsx
+++ b/packages/client/src/pages/account/waitOrders/WaitOrderInfo.tsx
@@ -39,7 +39,11 @@ function WaitOrderInfo({
 					{tradeType === 'buy' ? '매수' : '매도'}
 				</div>
 				<div className="w-[10%]">
-					<span>{price.toLocaleString()}</span>
+					<span>
+						{price < 1
+							? parseFloat(price.toFixed(5)).toString()
+							: price.toLocaleString()}
+					</span>
 					<span className="ml-1 text-xs text-gray-600">KRW</span>
 				</div>
 				<div className="w-[20%]">

--- a/packages/client/src/utility/format/formatSSEData.ts
+++ b/packages/client/src/utility/format/formatSSEData.ts
@@ -19,7 +19,9 @@ export const formatData = (category: MarketCategory) => {
 	switch (category) {
 		case 'KRW':
 			formatters.formatTradePrice = (price: number) =>
-				`${Number(price).toLocaleString()}원`;
+				price < 1
+					? `${parseFloat(price.toFixed(5)).toString()}원`
+					: `${Number(price).toLocaleString()}원`;
 
 			formatters.formatSignedChangePrice = (price: number, change: Change) => {
 				return `${decideSign(change) + Number(price).toLocaleString()}원`;


### PR DESCRIPTION
## ✅ 작업 내용

## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점
